### PR TITLE
Removes the override of SuperTab’s default completion type

### DIFF
--- a/dots/vimrc
+++ b/dots/vimrc
@@ -131,7 +131,6 @@ let g:NERDTreeMapUpdir='-'
 
 let g:SuperTabLongestEnhanced=1
 let g:SuperTabLongestHighlight=0
-let g:SuperTabDefaultCompletionType="<c-n>"
 
 " Open quick fix and location windows with ctrlp commands
 let g:qfenter_enable_autoquickfix=0


### PR DESCRIPTION
So using `<c-p>` is a little weird because the completion menu starts from the bottom and works it way to the top but it’s usually a shorter track to the desired term.

From the [SuperTab FAQ in the Readme](https://github.com/ervandew/supertab#frequently-asked-questions)…

> Why is `<c-p>` the supertab default? The original supertab author found (and I agree with his finding) that while coding, the keyword match you want is typically the closer of the matches above the cursor, which `<c-p>` naturally provides.

/cc @rynbyjn @jayzes 
