### PR TITLE
Update search tool to use Ag and vim-grepper

### DIFF
--- a/dots/vimrc
+++ b/dots/vimrc
@@ -187,8 +187,8 @@ nnoremap <silent><C-o> :BufSurfForward<CR>
 let g:ctrlp_map='<F1>'
 noremap <F2> :NERDTreeToggle<CR>
 noremap <F3> :CtrlPBuffer<CR>
-nmap <F4> <Plug>CtrlSFQuickfixPrompt
-vmap <F4> <Plug>CtrlSFQuickfixVwordExec
+nnoremap <F4> :Ag<space>
+xnoremap <F4> y:<c-u>Ag -Q <C-R>=shellescape(expand(@"),1)<CR>
 nmap <F5> <Plug>CtrlSFPrompt
 vmap <F5> <Plug>CtrlSFVwordExec
 noremap <F10> :vertical wincmd f<CR>
@@ -200,8 +200,8 @@ nnoremap <silent>gF :vertical wincmd f<CR>
 nnoremap <silent>gl :CtrlP<CR>
 nnoremap <silent>gL :CtrlPBuffer<CR>
 nnoremap <silent>gy :NERDTreeToggle<CR>
-nmap gs <Plug>CtrlSFQuickfixPrompt
-vmap gs <Plug>CtrlSFQuickfixVwordExec
+nnoremap gs :Ag<space>
+xnoremap gs y:<c-u>Ag -Q <C-R>=shellescape(expand(@"),1)<CR>
 nmap gz <Plug>CtrlSFPrompt
 vmap gz <Plug>CtrlSFVwordExec
 
@@ -228,6 +228,7 @@ endfunc
 if has("autocmd")
   augroup FTOptions
     autocmd!
+    autocmd User Grepper :resize 10
     autocmd QuickFixCmdPost *grep* botright copen
     autocmd BufNewFile,BufReadPost *.md set filetype=markdown
     autocmd FileType markdown,text,txt setlocal tw=80 linebreak nolist wrap spell


### PR DESCRIPTION
Moves the shortcut find in project tools over to Ag and [vim-grepper](https://github.com/mhinz/vim-grepper)

@jayzes this will make it very simple to swap out the underlying search tools (like moving from [the Silver Searcher](https://github.com/ggreer/the_silver_searcher) to [ripgrep](https://github.com/BurntSushi/ripgrep) or just [git-grep](https://git-scm.com/docs/git-grep)).
