### PR TITLE
Adds the vim-flow plugin for running flowtype

### DIFF
--- a/dots/vimrc
+++ b/dots/vimrc
@@ -31,6 +31,7 @@ Plug 'tpope/vim-unimpaired'
 Plug 'othree/html5.vim'
 Plug 'keith/swift.vim'
 Plug 'fatih/vim-go'
+Plug 'flowtype/vim-flow'
 Plug 'pangloss/vim-javascript'
 Plug 'mxw/vim-jsx'
 Plug 'tpope/vim-rails'
@@ -145,15 +146,23 @@ let g:qfenter_hopen_map=['<C-CR>', '<C-s>', '<C-x>']
 let g:qfenter_topen_map=['<C-t>']
 
 let g:syntastic_auto_loc_list=1
+
 let g:syntastic_css_checkers=['stylelint']
+if executable('node_modules/.bin/stylelint')
+  let g:syntastic_css_stylelint_exec='node_modules/.bin/stylelint'
+endif
+
 let g:syntastic_javascript_checkers=['eslint']
 let g:syntastic_javascript_eslint_args="--rule 'no-console: 0'"
 if executable('eslint_d')
   let g:syntastic_javascript_eslint_exec='eslint_d'
 endif
 
-if executable('node_modules/.bin/stylelint')
-  let g:syntastic_css_stylelint_exec='node_modules/.bin/stylelint'
+let g:flow#autoclose=1
+let g:flow#omnifunc=1
+let g:flow#qfsize=0
+if executable('node_modules/.bin/flow')
+  let g:flow#flowpath='node_modules/.bin/flow'
 endif
 
 let g:yankring_window_height=10


### PR DESCRIPTION
Added a few settings:

1. Use the local version of flow in node_modules if it exists
2. Close Flow's QF window when there are no errors
3. Don't use vim-flow's QF sizing (it jacks with other QF settings)
4. Enable omni-completion by default (haven't played with this yet)

There is a syntastic version of this.. but it's sort of whacky. When there is an error, flowtype reports 2 errors. One on the definition and one on the caller. The syntastic version only links to the definition and not the caller which is really probably the one you want. Also, the way that flowtype works is a server is running in the background which checks all files. With Syntastic, this means that errors are reported in every file in their own individual QF windows. This plugin, while not perfect gives a little better feedback and only in a single window.