### PR TITLE
 Remove vim-flow for syntastic's flow checker

### DIFF
--- a/dots/vimrc
+++ b/dots/vimrc
@@ -31,7 +31,6 @@ Plug 'tpope/vim-unimpaired'
 Plug 'othree/html5.vim'
 Plug 'keith/swift.vim'
 Plug 'fatih/vim-go'
-Plug 'flowtype/vim-flow'
 Plug 'pangloss/vim-javascript'
 Plug 'mxw/vim-jsx'
 Plug 'tpope/vim-rails'
@@ -146,23 +145,23 @@ let g:qfenter_hopen_map=['<C-CR>', '<C-s>', '<C-x>']
 let g:qfenter_topen_map=['<C-t>']
 
 let g:syntastic_auto_loc_list=1
+let g:syntastic_aggregate_errors=1
+let g:syntastic_always_populate_loc_list=1
 
 let g:syntastic_css_checkers=['stylelint']
 if executable('node_modules/.bin/stylelint')
   let g:syntastic_css_stylelint_exec='node_modules/.bin/stylelint'
 endif
 
-let g:syntastic_javascript_checkers=['eslint']
+let g:syntastic_javascript_checkers=['eslint', 'flow']
 let g:syntastic_javascript_eslint_args="--rule 'no-console: 0'"
 if executable('eslint_d')
   let g:syntastic_javascript_eslint_exec='eslint_d'
 endif
 
-let g:flow#autoclose=1
-let g:flow#omnifunc=1
-let g:flow#qfsize=0
 if executable('node_modules/.bin/flow')
-  let g:flow#flowpath='node_modules/.bin/flow'
+  let g:syntastic_javascript_flow_exec='node_modules/.bin/flow'
+  let g:syntastic_javascript_flow_exe='node_modules/.bin/flow --show-all-errors --json --quiet'
 endif
 
 let g:yankring_window_height=10


### PR DESCRIPTION
It's not perfect, but it seems to work a bit better than what we were using.