### PR TITLE
Add vim-rhubarb to the plugins

### DIFF
--- a/dots/vimrc
+++ b/dots/vimrc
@@ -40,6 +40,7 @@ Plug 'hashivim/vim-terraform'
 
 " Utility
 Plug 'tpope/vim-fugitive'
+Plug 'tpope/vim-rhubarb'
 
 " Add local bundles
 if filereadable(expand("~/.vimrc.bundles"))


### PR DESCRIPTION
Recently fugitive required the `Gbrowse` command to be accompanied by another plugin that taps into a provider. The vim-rhubarb plugin is the provider for GitHub. More info can be found at [vim-fugitive](https://github.com/tpope/vim-fugitive)

See the [vim-rhubarb plugin](https://github.com/tpope/vim-rhubarb) for other features.